### PR TITLE
External topics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ SHELL := /bin/sh
 
 include config.mk
 
-.PHONY:=c java c-bindings java-bindings c-examples java-examples clean
+.PHONY:=c-mash dotnet-mash java-mash c dotnet java c-bindings java-bindings java-bindings-ingress java-bindings-egress c-examples dotnet-examples java-examples clean-bin clean
 
 c-mash: clean c
+
+dotnet-mash: clean dotnet
 
 java-mash: clean java
 

--- a/bindings/java/mothra-jni-ingress.c
+++ b/bindings/java/mothra-jni-ingress.c
@@ -12,6 +12,20 @@ JNIEXPORT void JNICALL Java_net_p2p_mothra_Init(JNIEnv* jenv, jclass jcls)
    assert (rs == JNI_OK);
 }
 
+void (*s_discovered_peer_ptr)(const unsigned char* peer_utf8, int peer_length);
+void (*s_receive_gossip_ptr)(const unsigned char* topic_utf8, int topic_length, unsigned char* data, int data_length);
+void (*s_receive_rpc_ptr)(const unsigned char* method_utf8, int method_length, int req_resp, const unsigned char* peer_utf8, int peer_length, unsigned char* data, int data_length);
+
+void ingress_register_handlers(
+    void (*discovered_peer_ptr)(const unsigned char* peer_utf8, int peer_length), 
+    void (*receive_gossip_ptr)(const unsigned char* topic_utf8, int topic_length, unsigned char* data, int data_length), 
+    void (*receive_rpc_ptr)(const unsigned char* method_utf8, int method_length, int req_resp, const unsigned char* peer_utf8, int peer_length, unsigned char* data, int data_length)
+) {
+    s_discovered_peer_ptr = discovered_peer_ptr;
+    s_receive_gossip_ptr = receive_gossip_ptr;
+    s_receive_rpc_ptr = receive_rpc_ptr;
+}
+
 void discovered_peer(const unsigned char* peer, int peer_length) {
     JNIEnv *jenv;
     jint rs = (*jvm)->AttachCurrentThread(jvm, (void**)&jenv, NULL);

--- a/bindings/java/mothra-jni-ingress.h
+++ b/bindings/java/mothra-jni-ingress.h
@@ -8,6 +8,12 @@ extern "C" {
 
 JNIEXPORT void JNICALL Java_net_p2p_mothra_Init(JNIEnv*,jclass);
 
+void ingress_register_handlers(
+   void (*discovered_peer_ptr)(const unsigned char* peer_utf8, int peer_length), 
+   void (*receive_gossip_ptr)(const unsigned char* topic_utf8, int topic_length, unsigned char* data, int data_length), 
+   void (*receive_rpc_ptr)(const unsigned char* method_utf8, int method_length, int req_resp, const unsigned char* peer_utf8, int peer_length, unsigned char* data, int data_length)
+);
+
 void discovered_peer(const unsigned char*, int);
 void receive_gossip(const unsigned char*, int, unsigned char*, int);
 void receive_rpc(const unsigned char*, int, int, const unsigned char*, int, unsigned char*, int);

--- a/bindings/java/mothra.java
+++ b/bindings/java/mothra.java
@@ -5,7 +5,9 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public class mothra {
-    public static final String NAME = "mothra-egress";
+    public static final String CORE_NAME = "mothra";
+    public static final String EGRESS_NAME = "mothra-egress";
+    public static final String INGRESS_NAME = "mothra-ingress";
     public static Function<String, Boolean> DiscoveryMessage;
     public static BiFunction<String, byte[], Boolean> ReceivedGossipMessage;
     public static QuadFunction<String, Integer, String, byte[], Boolean> ReceivedRPCMessage;
@@ -24,7 +26,9 @@ public class mothra {
     }
     static {
         try {
-            System.loadLibrary ( NAME ) ;
+            System.loadLibrary ( CORE_NAME ) ;
+            System.loadLibrary ( EGRESS_NAME ) ;
+            System.loadLibrary ( INGRESS_NAME ) ;
         } catch (UnsatisfiedLinkError e) {
           System.err.println("Native code library failed to load.\n" + e);
           e.printStackTrace();

--- a/core/src/libp2p-wrapper/src/config.rs
+++ b/core/src/libp2p-wrapper/src/config.rs
@@ -6,18 +6,6 @@ use serde_derive::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::Duration;
 
-/// The gossipsub topic names.
-// These constants form a topic name of the form /TOPIC_PREFIX/TOPIC/ENCODING_POSTFIX
-// For example /eth2/beacon_block/ssz
-pub const TOPIC_PREFIX: &str = "eth2";
-pub const TOPIC_ENCODING_POSTFIX: &str = "ssz";
-pub const BEACON_BLOCK_TOPIC: &str = "beacon_block";
-pub const BEACON_ATTESTATION_TOPIC: &str = "beacon_attestation";
-pub const VOLUNTARY_EXIT_TOPIC: &str = "voluntary_exit";
-pub const PROPOSER_SLASHING_TOPIC: &str = "proposer_slashing";
-pub const ATTESTER_SLASHING_TOPIC: &str = "attester_slashing";
-pub const SHARD_TOPIC_PREFIX: &str = "shard";
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 /// Network configuration for artemis

--- a/core/src/libp2p-wrapper/src/lib.rs
+++ b/core/src/libp2p-wrapper/src/lib.rs
@@ -11,8 +11,7 @@ mod service;
 
 pub use behaviour::PubsubMessage;
 pub use config::{
-    Config as NetworkConfig, BEACON_ATTESTATION_TOPIC, BEACON_BLOCK_TOPIC, SHARD_TOPIC_PREFIX,TOPIC_ENCODING_POSTFIX, TOPIC_PREFIX,
-};
+    Config as NetworkConfig};
 pub use libp2p::gossipsub::{Topic, TopicHash};
 pub use libp2p::multiaddr;
 pub use libp2p::Multiaddr;

--- a/core/src/libp2p-wrapper/src/service.rs
+++ b/core/src/libp2p-wrapper/src/service.rs
@@ -5,7 +5,6 @@ use crate::multiaddr::Protocol;
 use crate::rpc::{RPCEvent};
 use crate::NetworkConfig;
 use crate::{Topic, TopicHash};
-use crate::{BEACON_ATTESTATION_TOPIC, BEACON_BLOCK_TOPIC};
 use futures::prelude::*;
 use futures::Stream;
 use libp2p::core::{
@@ -114,23 +113,6 @@ impl Service {
         // subscribe to default gossipsub topics
         let mut topics = vec![];
 
-
-       /* Here we subscribe to all the required gossipsub topics required for interop.
-         * The topic builder adds the required prefix and postfix to the hardcoded topics that we
-         * must subscribe to.
-         */
-        let topic_builder = |topic| {
-            Topic::new(format!(
-                "/{}/{}/{}",
-                TOPIC_PREFIX, topic, TOPIC_ENCODING_POSTFIX,
-            ))
-        };
-        topics.push(topic_builder(BEACON_BLOCK_TOPIC));
-        topics.push(topic_builder(BEACON_ATTESTATION_TOPIC));
-        topics.push(topic_builder(VOLUNTARY_EXIT_TOPIC));
-        topics.push(topic_builder(PROPOSER_SLASHING_TOPIC));
-        topics.push(topic_builder(ATTESTER_SLASHING_TOPIC));
-
         // Add any topics specified by the user
         topics.append(
             &mut config
@@ -175,23 +157,13 @@ impl Stream for Service {
                         message,
                     } => {
                         //debug!(self.log, "Gossipsub message received"; "Message" => format!("{:?}", topics[0]));
-                        if topics[0].to_string() == format!("/{}/{}/{}",TOPIC_PREFIX, BEACON_BLOCK_TOPIC, TOPIC_ENCODING_POSTFIX) {
-                            self.tx.lock().unwrap().send(Message {
-                                category: GOSSIP.to_string(),
-                                command: topics[0].to_string(),
-                                req_resp: Default::default(),
-                                peer: Default::default(),
-                                value: message.clone()
-                            }).unwrap();
-                        } else if topics[0].to_string() == format!("/{}/{}/{}",TOPIC_PREFIX, BEACON_ATTESTATION_TOPIC, TOPIC_ENCODING_POSTFIX) {
-                            self.tx.lock().unwrap().send(Message {
-                                category: GOSSIP.to_string(),
-                                command: topics[0].to_string(),
-                                req_resp: Default::default(),
-                                peer: Default::default(),
-                                value: message.clone()
-                            }).unwrap();
-                        } 
+                        self.tx.lock().unwrap().send(Message {
+                            category: GOSSIP.to_string(),
+                            command: topics[0].to_string(),
+                            req_resp: Default::default(),
+                            peer: Default::default(),
+                            value: message.clone()
+                        }).unwrap();
                         return Ok(Async::Ready(Some(Libp2pEvent::PubsubMessage {
                             source,
                             topics,

--- a/core/src/mothra_api/api.rs
+++ b/core/src/mothra_api/api.rs
@@ -12,7 +12,7 @@ use tokio::timer::Interval;
 use tokio_timer::clock::Clock;
 use futures::Future;
 use clap::{App, Arg, AppSettings};
-use libp2p_wrapper::{NetworkConfig, Topic, BEACON_ATTESTATION_TOPIC, BEACON_BLOCK_TOPIC,Message,GOSSIP,RPC,RPCRequest,RPCResponse,RPCErrorResponse,RPCEvent,PeerId};
+use libp2p_wrapper::{NetworkConfig,Topic,Message,GOSSIP,RPC,RPCRequest,RPCResponse,RPCErrorResponse,RPCEvent,PeerId};
 use tokio::sync::mpsc;
 use super::network::{Network,NetworkMessage,OutgoingMessage};
 
@@ -176,42 +176,45 @@ pub fn config(args: Vec<String>) -> ArgMatches<'static> {
     .arg(
         Arg::with_name("listen-address")
             .long("listen-address")
-            .value_name("Address")
-            .help("The address artemis will listen for UDP and TCP connections. (default 127.0.0.1).")
+            .value_name("ADDRESS")
+            .help("The address the client will listen for UDP and TCP connections. (default 127.0.0.1).")
+            .default_value("127.0.0.1")
+            .takes_value(true),
+    )
+    .arg(
+        Arg::with_name("port")
+            .long("port")
+            .value_name("PORT")
+            .help("The TCP/UDP port to listen on. The UDP port can be modified by the --discovery-port flag.")
             .takes_value(true),
     )
     .arg(
         Arg::with_name("maxpeers")
             .long("maxpeers")
             .help("The maximum number of peers (default 10).")
+            .default_value("10")
             .takes_value(true),
     )
     .arg(
         Arg::with_name("boot-nodes")
             .long("boot-nodes")
             .allow_hyphen_values(true)
-            .value_name("BOOTNODES")
+            .value_name("ENR-LIST")
             .help("One or more comma-delimited base64-encoded ENR's to bootstrap the p2p network.")
-            .takes_value(true),
-    )
-    .arg(
-        Arg::with_name("port")
-            .long("port")
-            .value_name("Artemis Port")
-            .help("The TCP/UDP port to listen on. The UDP port can be modified by the --discovery-port flag.")
             .takes_value(true),
     )
     .arg(
         Arg::with_name("discovery-port")
             .long("disc-port")
-            .value_name("DiscoveryPort")
+            .value_name("PORT")
             .help("The discovery UDP port.")
+            .default_value("9000")
             .takes_value(true),
     )
     .arg(
         Arg::with_name("discovery-address")
             .long("discovery-address")
-            .value_name("Address")
+            .value_name("ADDRESS")
             .help("The IP address to broadcast to other peers on how to reach this node.")
             .takes_value(true),
     )
@@ -233,8 +236,7 @@ pub fn config(args: Vec<String>) -> ArgMatches<'static> {
         Arg::with_name("debug-level")
             .long("debug-level")
             .value_name("LEVEL")
-            .short("s")
-            .help("The title of the spec constants for chain config.")
+            .help("Possible values: info, debug, trace, warn, error, crit")
             .takes_value(true)
             .possible_values(&["info", "debug", "trace", "warn", "error", "crit"])
             .default_value("info"),

--- a/examples/c/peerDemo.sh
+++ b/examples/c/peerDemo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-tmux new-session -d -s foo 'LD_LIBRARY_PATH=../../bin ./../../bin/example'
-tmux split-window -v -t 0 'LD_LIBRARY_PATH=../../bin ./../../bin/example --boot-nodes $(cat ~/.mothra/network/enr.dat) --listen-address 127.0.0.1 --port 9001 --datadir /tmp/.artemis'
+tmux new-session -d -s foo 'LD_LIBRARY_PATH=../../bin ./../../bin/example --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz'
+tmux split-window -v -t 0 'LD_LIBRARY_PATH=../../bin ./../../bin/example --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz --boot-nodes $(cat ~/.mothra/network/enr.dat) --listen-address 127.0.0.1 --port 9001 --datadir /tmp/.mothra'
 tmux select-layout tile
 tmux rename-window 'the dude abides'
 tmux attach-session -d

--- a/examples/dotnet/peerDemo.sh
+++ b/examples/dotnet/peerDemo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-tmux new-session -d -s foo 'dotnet ./../../bin/dotnet/Example.dll'
-tmux split-window -v -t 0 'dotnet ./../../bin/dotnet/Example.dll -- --boot-nodes $(cat ~/.mothra/network/enr.dat) --listen-address 127.0.0.1 --port 9001 --datadir /tmp/.artemis'
+tmux new-session -d -s foo 'dotnet ./../../bin/dotnet/Example.dll -- --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz'
+tmux split-window -v -t 0 'dotnet ./../../bin/dotnet/Example.dll -- --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz --boot-nodes $(cat ~/.mothra/network/enr.dat) --listen-address 127.0.0.1 --port 9001 --datadir /tmp/.mothra'
 tmux select-layout tile 
 tmux rename-window 'the dude abides'
 tmux attach-session -d

--- a/examples/java/example.java
+++ b/examples/java/example.java
@@ -26,7 +26,7 @@ public class example {
             if(messageType.equals("GOSSIP")){
                 System.out.print("Enter a message to GOSSIP: ");
                 String message = scanner.next();
-                mothra.SendGossip("beacon_block".getBytes(),message.getBytes());
+                mothra.SendGossip("/eth2/beacon_block/ssz".getBytes(),message.getBytes());
             } else if(messageType.equals("RPC")){
                 System.out.print("Enter Req/Resp (0/1): ");
                 int req_resp = Integer.parseInt(scanner.next());

--- a/examples/java/peerDemo.sh
+++ b/examples/java/peerDemo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-tmux new-session -d -s foo 'cd ./../../bin && java example'
-tmux split-window -v -t 0 'cd ./../../bin && java example --boot-nodes $(cat ~/.mothra/network/enr.dat) --listen-address 127.0.0.1 --port 9001 --datadir /tmp/.artemis'
+tmux new-session -d -s foo 'cd ./../../bin && java example --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz'
+tmux split-window -v -t 0 'cd ./../../bin && java example --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz --boot-nodes $(cat ~/.mothra/network/enr.dat) --listen-address 127.0.0.1 --port 9001 --datadir /tmp/.mothra'
 tmux select-layout tile
 tmux rename-window 'the dude abides'
 tmux attach-session -d


### PR DESCRIPTION
Builds on #18 (Review that first)

Resolves #3 

Gossip topics are now passed in as external arguments. 


Here is an example of how to run (without peerDemo.sh):

```
LD_LIBRARY_PATH=../../bin ./../../bin/example --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz

LD_LIBRARY_PATH=../../bin ./../../bin/example --topics /eth2/beacon_block/ssz,/eth2/beacon_attestation/ssz,/eth2/voluntary_exit/ssz,/eth2/proposer_slashing/ssz,/eth2/attester_slashing/ssz --boot-nodes $(cat ~/.mothra/network/enr.dat) --listen-address 127.0.0.1 --port 9001 --datadir /tmp/.mothra
```