### PR TITLE
dependency cleanup

### DIFF
--- a/core/src/api/ffi.rs
+++ b/core/src/api/ffi.rs
@@ -1,7 +1,6 @@
 use crate::{network, network::NetworkMessage, network::NetworkService};
-use cast::i16;
 use libp2p_wrapper::NetworkGlobals;
-use slog::{debug, info, o, warn, Drain};
+use cast::i16;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_uchar};
 use std::sync::Arc;

--- a/core/src/api/ffi.rs
+++ b/core/src/api/ffi.rs
@@ -1,6 +1,6 @@
 use crate::{network, network::NetworkMessage, network::NetworkService};
-use libp2p_wrapper::NetworkGlobals;
 use cast::i16;
+use libp2p_wrapper::NetworkGlobals;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_uchar};
 use std::sync::Arc;

--- a/core/src/api/network.rs
+++ b/core/src/api/network.rs
@@ -1,13 +1,13 @@
 use super::error;
-use env_logger::Env;
-use futures::prelude::*;
-use futures::Stream;
 use libp2p_wrapper::Service as LibP2PService;
 use libp2p_wrapper::{
     Enr, GossipTopic, NetworkConfig, NetworkGlobals, RPCErrorResponse, RPCEvent, RPCRequest,
-    RPCResponse,
+    RPCResponse, Libp2pEvent, MessageId, PeerId, Swarm
 };
-use libp2p_wrapper::{Libp2pEvent, MessageId, PeerId, Swarm};
+
+use env_logger::Env;
+use futures::prelude::*;
+use futures::Stream;
 use slog::{debug, info, o, trace, warn, Drain, Level, Logger};
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/core/src/api/network.rs
+++ b/core/src/api/network.rs
@@ -1,8 +1,8 @@
 use super::error;
 use libp2p_wrapper::Service as LibP2PService;
 use libp2p_wrapper::{
-    Enr, GossipTopic, NetworkConfig, NetworkGlobals, RPCErrorResponse, RPCEvent, RPCRequest,
-    RPCResponse, Libp2pEvent, MessageId, PeerId, Swarm
+    Enr, GossipTopic, Libp2pEvent, MessageId, NetworkConfig, NetworkGlobals, PeerId,
+    RPCErrorResponse, RPCEvent, RPCRequest, RPCResponse, Swarm,
 };
 
 use env_logger::Env;

--- a/core/src/libp2p-wrapper/Cargo.toml
+++ b/core/src/libp2p-wrapper/Cargo.toml
@@ -5,15 +5,13 @@ authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
 
 [dependencies]
-hex = "0.3"
 libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "4e3003d5283040fee10da1299252dd060a838d97" }
-ssz_types = { git = "https://github.com/jrhea/lighthouse", rev = "a91881251d6ebdd2f1d216aed036168456d5f89c", package = "eth2_ssz_types" }
 types = { git = "https://github.com/jrhea/lighthouse", rev = "a91881251d6ebdd2f1d216aed036168456d5f89c", package = "types" }
+ssz = { git = "https://github.com/jrhea/lighthouse", rev = "a91881251d6ebdd2f1d216aed036168456d5f89c", package = "eth2_ssz" }
+hex = "0.3"
 clap = "2.32.0"
 serde = "1.0.102"
 serde_derive = "1.0.102"
-ssz = { git = "https://github.com/jrhea/lighthouse", rev = "a91881251d6ebdd2f1d216aed036168456d5f89c", package = "eth2_ssz" }
-ssz_derive = { git = "https://github.com/jrhea/lighthouse", rev = "a91881251d6ebdd2f1d216aed036168456d5f89c", package = "eth2_ssz_derive" }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 tokio = "0.1.22"
 tokio-io = "0.1.12"

--- a/core/src/libp2p-wrapper/src/config.rs
+++ b/core/src/libp2p-wrapper/src/config.rs
@@ -1,10 +1,9 @@
-use super::error;
-use crate::{Enr, version};
-use clap::{App, AppSettings, Arg, ArgMatches};
+use crate::{Enr, version, error};
 use libp2p::discv5::{Discv5Config, Discv5ConfigBuilder};
 use libp2p::gossipsub::{GossipsubConfig, GossipsubConfigBuilder, GossipsubMessage, MessageId};
 use libp2p::Multiaddr;
 use serde_derive::{Deserialize, Serialize};
+use clap::{App, AppSettings, Arg, ArgMatches};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::time::Duration;

--- a/core/src/libp2p-wrapper/src/lib.rs
+++ b/core/src/libp2p-wrapper/src/lib.rs
@@ -6,13 +6,9 @@ mod service;
 pub mod types;
 mod version;
 
-// shift this type into discv5
-pub type Enr = libp2p::discv5::enr::Enr<libp2p::discv5::enr::CombinedKey>;
-
-pub use crate::types::{error, NetworkGlobals, PeerInfo, GossipTopic};
+pub use crate::types::{error, NetworkGlobals, PeerInfo, GossipTopic, Enr, EnrBitfield, EnrForkId, SubnetId};
 pub use config::Config as NetworkConfig;
 pub use libp2p::gossipsub::{MessageId, Topic, TopicHash};
-pub use libp2p::{multiaddr, Multiaddr};
-pub use libp2p::{PeerId, Swarm};
+pub use libp2p::{PeerId, Swarm, multiaddr, Multiaddr};
 pub use rpc::{RPCErrorResponse, RPCEvent, RPCRequest, RPCResponse};
 pub use service::{Libp2pEvent, Service};

--- a/core/src/libp2p-wrapper/src/service.rs
+++ b/core/src/libp2p-wrapper/src/service.rs
@@ -2,9 +2,7 @@ use crate::behaviour::{Behaviour, BehaviourEvent};
 use crate::multiaddr::Protocol;
 use crate::rpc::RPCEvent;
 use crate::types::error;
-use crate::{NetworkConfig, NetworkGlobals, GossipTopic, TopicHash};
-use futures::prelude::*;
-use futures::Stream;
+use crate::{NetworkConfig, NetworkGlobals, GossipTopic, TopicHash, EnrForkId};
 use libp2p::core::{
     identity::Keypair,
     multiaddr::Multiaddr,
@@ -16,6 +14,8 @@ use libp2p::core::{
 };
 use libp2p::gossipsub::MessageId;
 use libp2p::{core, noise, secio, swarm::NetworkBehaviour, PeerId, Swarm, Transport};
+use futures::prelude::*;
+use futures::Stream;
 use slog::{crit, debug, error, info, trace, warn};
 use std::fs::File;
 use std::io::prelude::*;
@@ -54,7 +54,7 @@ pub struct Service {
 impl Service {
     pub fn new(
         config: &NetworkConfig,
-        enr_fork_id: Vec<u8>,
+        enr_fork_id: EnrForkId,
         log: slog::Logger,
     ) -> error::Result<(Arc<NetworkGlobals>, Self)> {
         trace!(log, "Libp2p Service starting");

--- a/core/src/libp2p-wrapper/src/types/globals.rs
+++ b/core/src/libp2p-wrapper/src/types/globals.rs
@@ -3,7 +3,6 @@ use crate::{Enr, GossipTopic, Multiaddr, PeerId, PeerInfo};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU16, Ordering};
-use types::MainnetEthSpec;
 
 pub struct NetworkGlobals {
     /// The current local ENR.
@@ -17,7 +16,7 @@ pub struct NetworkGlobals {
     /// The udp port that the discovery service is listening on
     pub listen_port_udp: AtomicU16,
     /// The collection of currently connected peers.
-    pub connected_peer_set: RwLock<HashMap<PeerId, PeerInfo<MainnetEthSpec>>>,
+    pub connected_peer_set: RwLock<HashMap<PeerId, PeerInfo>>,
     /// The current gossipsub topic subscriptions.
     pub gossipsub_subscriptions: RwLock<HashSet<GossipTopic>>,
 }

--- a/core/src/libp2p-wrapper/src/types/mod.rs
+++ b/core/src/libp2p-wrapper/src/types/mod.rs
@@ -4,5 +4,14 @@ mod peer_info;
 mod topics;
 
 pub use globals::NetworkGlobals;
-pub use peer_info::{EnrBitfield, PeerInfo};
-pub use topics::{GossipTopic};
+pub use peer_info::PeerInfo;
+pub use topics::GossipTopic;
+
+use types::{BitVector, EthSpec, MainnetEthSpec};
+
+#[allow(type_alias_bounds)]
+pub type EnrBitfield = BitVector<<MainnetEthSpec as EthSpec>::SubnetBitfieldLength>;
+pub type SubnetId = u64;
+pub type EnrForkId = Vec<u8>;
+// shift this type into discv5
+pub type Enr = libp2p::discv5::enr::Enr<libp2p::discv5::enr::CombinedKey>;

--- a/core/src/libp2p-wrapper/src/types/peer_info.rs
+++ b/core/src/libp2p-wrapper/src/types/peer_info.rs
@@ -1,19 +1,15 @@
 //NOTE: This should be removed in favour of the PeerManager PeerInfo, once built.
-
-use types::{BitVector, EthSpec, SubnetId};
-
-#[allow(type_alias_bounds)]
-pub type EnrBitfield<T: EthSpec> = BitVector<T::SubnetBitfieldLength>;
+use crate::{EnrBitfield, SubnetId};
 
 /// Information about a given connected peer.
 #[derive(Debug, Clone)]
-pub struct PeerInfo<T: EthSpec> {
+pub struct PeerInfo {
     /// The current syncing state of the peer. The state may be determined after it's initial
     /// connection.
     pub syncing_state: Option<PeerSyncingState>,
     /// The ENR subnet bitfield of the peer. This may be determined after it's initial
     /// connection.
-    pub enr_bitfield: Option<EnrBitfield<T>>,
+    pub enr_bitfield: Option<EnrBitfield>,
 }
 
 #[derive(Debug, Clone)]
@@ -26,7 +22,7 @@ pub enum PeerSyncingState {
     Behind,
 }
 
-impl<T: EthSpec> PeerInfo<T> {
+impl PeerInfo {
     /// Creates a new PeerInfo, specifying it's
     pub fn new() -> Self {
         PeerInfo {
@@ -38,7 +34,7 @@ impl<T: EthSpec> PeerInfo<T> {
     /// Returns if the peer is subscribed to a given `SubnetId`
     pub fn on_subnet(&self, subnet_id: SubnetId) -> bool {
         if let Some(bitfield) = &self.enr_bitfield {
-            return bitfield.get(*subnet_id as usize).unwrap_or_else(|_| false);
+            return bitfield.get(subnet_id as usize).unwrap_or_else(|_| false);
         }
         false
     }


### PR DESCRIPTION
isolating dependency on eth2 types like: `EnrBitfield`, `SubnetId`, `EnrForkId`