### PR TITLE
remove eth2 deps 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ members = [
 ]
 
 [patch.crates-io]
-tree_hash = { git = "https://github.com/jrhea/lighthouse", rev = "7259d2bd5630e218186bfc877fd69c72427f21a1", package = "tree_hash" }
-tree_hash_derive = { git = "https://github.com/jrhea/lighthouse", rev = "7259d2bd5630e218186bfc877fd69c72427f21a1", package = "tree_hash_derive" }
-eth2_ssz = { git = "https://github.com/jrhea/lighthouse", rev = "7259d2bd5630e218186bfc877fd69c72427f21a1", package = "eth2_ssz" }
-eth2_ssz_derive = { git = "https://github.com/jrhea/lighthouse", rev = "7259d2bd5630e218186bfc877fd69c72427f21a1", package = "eth2_ssz_derive" }
-eth2_ssz_types = { git = "https://github.com/jrhea/lighthouse", rev = "7259d2bd5630e218186bfc877fd69c72427f21a1", package = "eth2_ssz_types" }
-types = { git = "https://github.com/jrhea/lighthouse", rev = "7259d2bd5630e218186bfc877fd69c72427f21a1", package = "types" }
-eth2_hashing = { git = "https://github.com/jrhea/lighthouse", rev = "7259d2bd5630e218186bfc877fd69c72427f21a1", package = "eth2_hashing" }
+tree_hash = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "tree_hash" }
+tree_hash_derive = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "tree_hash_derive" }
+eth2_ssz = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_ssz" }
+eth2_ssz_derive = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_ssz_derive" }
+eth2_ssz_types = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_ssz_types" }
+types = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "types" }
+eth2_hashing = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_hashing" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "examples/rust"
 ]
 
+[patch.crates-io]
+libp2p = { git = "https://github.com/sigp/rust-libp2p", rev= "71cf486b4d992862f5a05f9f4ef5e5c1631f4add", package = "libp2p" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,3 @@ members = [
     "examples/rust"
 ]
 
-[patch.crates-io]
-tree_hash = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "tree_hash" }
-tree_hash_derive = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "tree_hash_derive" }
-eth2_ssz = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_ssz" }
-eth2_ssz_derive = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_ssz_derive" }
-eth2_ssz_types = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_ssz_types" }
-types = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "types" }
-eth2_hashing = { git = "https://github.com/jrhea/lighthouse", branch = "prkl", package = "eth2_hashing" }
-

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/sh
 
 include config.mk
 
-.PHONY: all mash core c dotnet java dotnet-bindings java-bindings rust-examples c-examples dotnet-examples java-examples touch lint clean
+.PHONY: all mash core c dotnet java dotnet-bindings java-bindings rust-examples c-examples dotnet-examples java-examples lint clean
 
 .DEFAULT: all
 
@@ -52,15 +52,6 @@ java-examples: java-bindings
 	@echo ""
 	@echo Building Java examples
 	cd $(JEXAMPLES_DIR) && make $@
-
-touch: 
-	cargo update -p tree_hash
-	cargo update -p tree_hash_derive
-	cargo update -p eth2_ssz
-	cargo update -p eth2_ssz_derive
-	cargo update -p eth2_ssz_types
-	cargo update -p types
-	cargo update -p eth2_hashing
 
 lint: 
 	cargo fmt

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/sh
 
 include config.mk
 
-.PHONY: all mash core c dotnet java dotnet-bindings java-bindings rust-examples c-examples dotnet-examples java-examples lint clean
+.PHONY: all mash core c dotnet java dotnet-bindings java-bindings rust-examples c-examples dotnet-examples java-examples touch lint clean
 
 .DEFAULT: all
 
@@ -52,6 +52,15 @@ java-examples: java-bindings
 	@echo ""
 	@echo Building Java examples
 	cd $(JEXAMPLES_DIR) && make $@
+
+touch: 
+	cargo update -p tree_hash
+	cargo update -p tree_hash_derive
+	cargo update -p eth2_ssz
+	cargo update -p eth2_ssz_derive
+	cargo update -p eth2_ssz_types
+	cargo update -p types
+	cargo update -p eth2_hashing
 
 lint: 
 	cargo fmt

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 libp2p =  { git = "https://github.com/sigp/rust-libp2p", rev = "71cf486b4d992862f5a05f9f4ef5e5c1631f4add", package = "libp2p"}
-types = "0.2.0"
-eth2_ssz = "0.1.2"
+eth2_types =  { version = "0.2.0",  package = "types" }
+eth2_ssz =  { version = "0.1.2",  package = "eth2_ssz"}
 hex = "0.3"
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -7,7 +7,7 @@ description = "Mothra p2p network layer."
 license = "Apache-2.0"
 
 [dependencies]
-libp2p =  { git = "https://github.com/sigp/rust-libp2p", rev = "71cf486b4d992862f5a05f9f4ef5e5c1631f4add", package = "libp2p"}
+libp2p = "0.13.2"
 hex = "0.3"
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -8,8 +8,6 @@ license = "Apache-2.0"
 
 [dependencies]
 libp2p =  { git = "https://github.com/sigp/rust-libp2p", rev = "71cf486b4d992862f5a05f9f4ef5e5c1631f4add", package = "libp2p"}
-eth2_types =  { version = "0.2.0",  package = "types" }
-eth2_ssz =  { version = "0.1.2",  package = "eth2_ssz"}
 hex = "0.3"
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/core/network/src/behaviour.rs
+++ b/core/network/src/behaviour.rs
@@ -1,7 +1,7 @@
 use crate::discovery::Discovery;
 use crate::rpc::{RPCEvent, RPCMessage, RPC};
 use crate::{
-    error, Enr, EnrForkId, GossipTopic, NetworkConfig, NetworkGlobals, SubnetId, TopicHash,
+    error, Enr, CombinedKey, EnrForkId, GossipTopic, NetworkConfig, NetworkGlobals, TopicHash,
 };
 use futures::prelude::*;
 use libp2p::{
@@ -159,12 +159,12 @@ impl<TSubstream: AsyncRead + AsyncWrite> Behaviour<TSubstream> {
     }
 
     /// Returns an iterator over all enr entries in the DHT.
-    pub fn enr_entries(&mut self) -> impl Iterator<Item = &Enr> {
+    pub fn enr_entries(&mut self) -> impl Iterator<Item = &Enr<CombinedKey>> {
         self.discovery.enr_entries()
     }
 
     // /// Add an ENR to the routing table of the discovery mechanism.
-    pub fn add_enr(&mut self, enr: Enr) {
+    pub fn add_enr(&mut self, enr: Enr<CombinedKey>) {
         self.discovery.add_enr(enr);
     }
 

--- a/core/network/src/behaviour.rs
+++ b/core/network/src/behaviour.rs
@@ -1,7 +1,7 @@
 use crate::discovery::Discovery;
 use crate::rpc::{RPCEvent, RPCMessage, RPC};
 use crate::{
-    error, Enr, CombinedKey, EnrForkId, GossipTopic, NetworkConfig, NetworkGlobals, TopicHash,
+    error, CombinedKey, Enr, EnrForkId, GossipTopic, NetworkConfig, NetworkGlobals, TopicHash,
 };
 use futures::prelude::*;
 use libp2p::{

--- a/core/network/src/behaviour.rs
+++ b/core/network/src/behaviour.rs
@@ -168,21 +168,6 @@ impl<TSubstream: AsyncRead + AsyncWrite> Behaviour<TSubstream> {
         self.discovery.add_enr(enr);
     }
 
-    /// Updates a subnet value to the ENR bitfield.
-    ///
-    /// The `value` is `true` if a subnet is being added and false otherwise.
-    //TODO: revisit bc update_enr_bitfield requires ssz
-    pub fn update_enr_subnet(&mut self, subnet_id: SubnetId, value: bool) {
-        if let Err(e) = self.discovery.update_enr_bitfield(subnet_id, value) {
-            crit!(self.log, "Could not update ENR bitfield"; "error" => e);
-        }
-    }
-
-    /// A request to search for peers connected to a long-lived subnet.
-    pub fn peers_request(&mut self, subnet_id: SubnetId) {
-        self.discovery.peers_request(subnet_id);
-    }
-
     /// Updates the local ENR's "eth2" field with the latest EnrForkId.
     //TODO: fix the fact that the fork digest isnt updated
     pub fn update_fork_version(&mut self, enr_fork_id: EnrForkId) {

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -1,5 +1,5 @@
 extern crate target_info;
-use crate::{error, Enr, DEFAULT_CLIENT_NAME};
+use crate::{error, Enr, CombinedKey, DEFAULT_CLIENT_NAME};
 use libp2p::discv5::{Discv5Config, Discv5ConfigBuilder};
 use libp2p::gossipsub::{GossipsubConfig, GossipsubConfigBuilder, GossipsubMessage, MessageId};
 use libp2p::Multiaddr;
@@ -61,7 +61,7 @@ pub struct Config {
     pub discv5_config: Discv5Config,
 
     /// List of nodes to initially connect to.
-    pub boot_nodes: Vec<Enr>,
+    pub boot_nodes: Vec<Enr<CombinedKey>>,
 
     /// List of libp2p nodes to initially connect to.
     pub libp2p_nodes: Vec<Multiaddr>,

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -103,7 +103,7 @@ impl Default for Config {
         // parameter.
         let gs_config = GossipsubConfigBuilder::new()
             .max_transmit_size(GOSSIP_MAX_SIZE)
-            .heartbeat_interval(Duration::from_secs(20)) // TODO: Reduce for mainnet
+            .heartbeat_interval(Duration::from_secs(1))
             .manual_propagation() // require validation before propagation
             .no_source_id()
             .message_id_fn(gossip_message_id)

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -1,5 +1,5 @@
 extern crate target_info;
-use crate::{error, Enr, CombinedKey, DEFAULT_CLIENT_NAME};
+use crate::{error, CombinedKey, Enr, DEFAULT_CLIENT_NAME};
 use libp2p::discv5::{Discv5Config, Discv5ConfigBuilder};
 use libp2p::gossipsub::{GossipsubConfig, GossipsubConfigBuilder, GossipsubMessage, MessageId};
 use libp2p::Multiaddr;

--- a/core/network/src/discovery/enr_helpers.rs
+++ b/core/network/src/discovery/enr_helpers.rs
@@ -3,7 +3,7 @@ use crate::{Enr, EnrBitfield, EnrForkId, NetworkConfig};
 use libp2p::core::identity::Keypair;
 use libp2p::discv5::enr::{CombinedKey, EnrBuilder};
 use slog::{debug, warn};
-use ssz::Encode;
+use eth2_ssz::Encode;
 use std::convert::TryInto;
 use std::fs::File;
 use std::io::prelude::*;

--- a/core/network/src/discovery/enr_helpers.rs
+++ b/core/network/src/discovery/enr_helpers.rs
@@ -3,7 +3,7 @@ use crate::{Enr, EnrBitfield, EnrForkId, NetworkConfig};
 use libp2p::core::identity::Keypair;
 use libp2p::discv5::enr::{CombinedKey, EnrBuilder};
 use slog::{debug, warn};
-use eth2_ssz::Encode;
+//use eth2_ssz::Encode;
 use std::convert::TryInto;
 use std::fs::File;
 use std::io::prelude::*;
@@ -92,14 +92,13 @@ fn build_enr(
 
     // set the `eth2` field on our ENR
 
-    // builder.add_value(ETH2_ENR_KEY.into(), enr_fork_id.as_ssz_bytes());
     // TODO: fix this
     builder.add_value(ETH2_ENR_KEY.into(), enr_fork_id);
 
     // set the "attnets" field on our ENR
     // TODO: fix this
-    let bitfield = EnrBitfield::new();
-    builder.add_value(BITFIELD_ENR_KEY.into(), bitfield.as_ssz_bytes());
+    let bitfield = [0u8; 8].to_vec();
+    builder.add_value(BITFIELD_ENR_KEY.into(), bitfield);
 
     builder
         .tcp(config.libp2p_port)

--- a/core/network/src/discovery/enr_helpers.rs
+++ b/core/network/src/discovery/enr_helpers.rs
@@ -1,5 +1,5 @@
 use super::ENR_FILENAME;
-use crate::{Enr, CombinedKey, EnrForkId, NetworkConfig};
+use crate::{CombinedKey, Enr, EnrForkId, NetworkConfig};
 use libp2p::core::identity::Keypair;
 use libp2p::discv5::enr::EnrBuilder;
 use slog::{debug, warn};

--- a/core/network/src/discovery/mod.rs
+++ b/core/network/src/discovery/mod.rs
@@ -12,7 +12,7 @@ use libp2p::discv5::{Discv5, Discv5Event};
 use libp2p::multiaddr::Protocol;
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters, ProtocolsHandler};
 use slog::{crit, debug, info, trace, warn};
-use ssz::{Decode, Encode};
+use eth2_ssz::{Decode, Encode};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::Path;

--- a/core/network/src/discovery/mod.rs
+++ b/core/network/src/discovery/mod.rs
@@ -1,13 +1,11 @@
 ///! This manages the discovery and management of peers.
 mod enr_helpers;
 
-use crate::{
-    error, Enr, CombinedKey, EnrForkId, NetworkConfig, NetworkGlobals, PeerInfo
-};
+use crate::{error, CombinedKey, Enr, EnrForkId, NetworkConfig, NetworkGlobals, PeerInfo};
 use enr_helpers::{BITFIELD_ENR_KEY, ETH2_ENR_KEY};
 use futures::prelude::*;
 use libp2p::core::{identity::Keypair, ConnectedPoint, Multiaddr, PeerId};
-use libp2p::discv5::enr::{NodeId};
+use libp2p::discv5::enr::NodeId;
 use libp2p::discv5::{Discv5, Discv5Event};
 use libp2p::multiaddr::Protocol;
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters, ProtocolsHandler};
@@ -163,7 +161,6 @@ impl<TSubstream> Discovery<TSubstream> {
         self.discovery.enr_entries()
     }
 
-
     /// Updates the `eth2` field of our local ENR.
     pub fn update_eth2_enr(&mut self, enr_fork_id: EnrForkId) {
         info!(self.log, "Updating the ENR fork version");
@@ -204,8 +201,10 @@ impl<TSubstream> Discovery<TSubstream> {
 
         let enr_fork_id = self.enr_fork_id();
         // predicate for finding nodes with a matching fork
-        let eth2_fork_predicate = move |enr: &Enr<CombinedKey>| enr.get(ETH2_ENR_KEY) == Some(&enr_fork_id);
-        let predicate = move |enr: &Enr<CombinedKey>| eth2_fork_predicate(enr) && enr_predicate(enr);
+        let eth2_fork_predicate =
+            move |enr: &Enr<CombinedKey>| enr.get(ETH2_ENR_KEY) == Some(&enr_fork_id);
+        let predicate =
+            move |enr: &Enr<CombinedKey>| eth2_fork_predicate(enr) && enr_predicate(enr);
 
         // general predicate
         self.discovery

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -5,14 +5,12 @@ pub mod rpc;
 mod service;
 pub mod types;
 
-pub use crate::types::{
-    error, EnrBitfield, EnrForkId, GossipTopic, NetworkGlobals, PeerInfo
-};
+pub use crate::types::{error, EnrBitfield, EnrForkId, GossipTopic, NetworkGlobals, PeerInfo};
 pub use config::unused_port;
 pub use config::Config as NetworkConfig;
+pub use libp2p::discv5::enr::{CombinedKey, Enr};
 pub use libp2p::gossipsub::{MessageId, Topic, TopicHash};
 pub use libp2p::{multiaddr, Multiaddr, PeerId, Swarm};
-pub use libp2p::discv5::enr::{Enr, CombinedKey};
 pub use rpc::{RPCErrorResponse, RPCEvent, RPCRequest, RPCResponse};
 pub use service::{Libp2pEvent, Service};
 

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -6,12 +6,13 @@ mod service;
 pub mod types;
 
 pub use crate::types::{
-    error, Enr, EnrBitfield, EnrForkId, GossipTopic, NetworkGlobals, PeerInfo, SubnetId,
+    error, EnrBitfield, EnrForkId, GossipTopic, NetworkGlobals, PeerInfo
 };
 pub use config::unused_port;
 pub use config::Config as NetworkConfig;
 pub use libp2p::gossipsub::{MessageId, Topic, TopicHash};
 pub use libp2p::{multiaddr, Multiaddr, PeerId, Swarm};
+pub use libp2p::discv5::enr::{Enr, CombinedKey};
 pub use rpc::{RPCErrorResponse, RPCEvent, RPCRequest, RPCResponse};
 pub use service::{Libp2pEvent, Service};
 

--- a/core/network/src/types/globals.rs
+++ b/core/network/src/types/globals.rs
@@ -1,5 +1,5 @@
 //! A collection of variables that are accessible outside of the network thread itself.
-use crate::{Enr, CombinedKey, GossipTopic, Multiaddr, PeerId, PeerInfo};
+use crate::{CombinedKey, Enr, GossipTopic, Multiaddr, PeerId, PeerInfo};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU16, Ordering};

--- a/core/network/src/types/globals.rs
+++ b/core/network/src/types/globals.rs
@@ -1,12 +1,12 @@
 //! A collection of variables that are accessible outside of the network thread itself.
-use crate::{Enr, GossipTopic, Multiaddr, PeerId, PeerInfo};
+use crate::{Enr, CombinedKey, GossipTopic, Multiaddr, PeerId, PeerInfo};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU16, Ordering};
 
 pub struct NetworkGlobals {
     /// The current local ENR.
-    pub local_enr: RwLock<Option<Enr>>,
+    pub local_enr: RwLock<Option<Enr<CombinedKey>>>,
     /// The local peer_id.
     pub peer_id: RwLock<PeerId>,
     /// Listening multiaddrs.
@@ -36,7 +36,7 @@ impl NetworkGlobals {
 
     /// Returns the local ENR from the underlying Discv5 behaviour that external peers may connect
     /// to.
-    pub fn local_enr(&self) -> Option<Enr> {
+    pub fn local_enr(&self) -> Option<Enr<CombinedKey>> {
         self.local_enr.read().clone()
     }
 

--- a/core/network/src/types/mod.rs
+++ b/core/network/src/types/mod.rs
@@ -7,7 +7,7 @@ pub use globals::NetworkGlobals;
 pub use peer_info::PeerInfo;
 pub use topics::GossipTopic;
 
-use types::{BitVector, EthSpec, MainnetEthSpec};
+use eth2_types::{BitVector, EthSpec, MainnetEthSpec};
 
 #[allow(type_alias_bounds)]
 pub type EnrBitfield = BitVector<<MainnetEthSpec as EthSpec>::SubnetBitfieldLength>;

--- a/core/network/src/types/mod.rs
+++ b/core/network/src/types/mod.rs
@@ -9,7 +9,4 @@ pub use topics::GossipTopic;
 
 #[allow(type_alias_bounds)]
 pub type EnrBitfield = Vec<u8>;
-pub type SubnetId = u64;
 pub type EnrForkId = Vec<u8>;
-// shift this type into discv5
-pub type Enr = libp2p::discv5::enr::Enr<libp2p::discv5::enr::CombinedKey>;

--- a/core/network/src/types/mod.rs
+++ b/core/network/src/types/mod.rs
@@ -7,10 +7,8 @@ pub use globals::NetworkGlobals;
 pub use peer_info::PeerInfo;
 pub use topics::GossipTopic;
 
-use eth2_types::{BitVector, EthSpec, MainnetEthSpec};
-
 #[allow(type_alias_bounds)]
-pub type EnrBitfield = BitVector<<MainnetEthSpec as EthSpec>::SubnetBitfieldLength>;
+pub type EnrBitfield = Vec<u8>;
 pub type SubnetId = u64;
 pub type EnrForkId = Vec<u8>;
 // shift this type into discv5

--- a/core/network/src/types/peer_info.rs
+++ b/core/network/src/types/peer_info.rs
@@ -30,12 +30,4 @@ impl PeerInfo {
             enr_bitfield: None,
         }
     }
-
-    /// Returns if the peer is subscribed to a given `SubnetId`
-    pub fn on_subnet(&self, subnet_id: SubnetId) -> bool {
-        if let Some(bitfield) = &self.enr_bitfield {
-            return bitfield.get(subnet_id as usize).unwrap_or_else(|_| false);
-        }
-        false
-    }
 }

--- a/core/network/src/types/peer_info.rs
+++ b/core/network/src/types/peer_info.rs
@@ -1,5 +1,5 @@
 //NOTE: This should be removed in favour of the PeerManager PeerInfo, once built.
-use crate::{EnrBitfield, SubnetId};
+use crate::{EnrBitfield};
 
 /// Information about a given connected peer.
 #[derive(Default, Debug, Clone)]

--- a/core/network/src/types/peer_info.rs
+++ b/core/network/src/types/peer_info.rs
@@ -1,5 +1,5 @@
 //NOTE: This should be removed in favour of the PeerManager PeerInfo, once built.
-use crate::{EnrBitfield};
+use crate::EnrBitfield;
 
 /// Information about a given connected peer.
 #[derive(Default, Debug, Clone)]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,5 +1,5 @@
 use clap::ArgMatches;
-use network::{unused_port, Enr, CombinedKey, Multiaddr, NetworkConfig, DEFAULT_CLIENT_NAME};
+use network::{unused_port, CombinedKey, Enr, Multiaddr, NetworkConfig, DEFAULT_CLIENT_NAME};
 use std::path::PathBuf;
 
 pub const DEFAULT_DEBUG_LEVEL: &str = "info";

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,5 +1,5 @@
 use clap::ArgMatches;
-use network::{unused_port, Enr, Multiaddr, NetworkConfig, DEFAULT_CLIENT_NAME};
+use network::{unused_port, Enr, CombinedKey, Multiaddr, NetworkConfig, DEFAULT_CLIENT_NAME};
 use std::path::PathBuf;
 
 pub const DEFAULT_DEBUG_LEVEL: &str = "info";
@@ -94,7 +94,7 @@ impl Config {
             self.network_config.boot_nodes = boot_enr_str
                 .split(',')
                 .map(|enr| enr.parse().map_err(|_| format!("Invalid ENR: {}", enr)))
-                .collect::<Result<Vec<Enr>, _>>()?;
+                .collect::<Result<Vec<Enr<CombinedKey>>, _>>()?;
         }
 
         if let Some(libp2p_addresses_str) = args.value_of("libp2p-addresses") {

--- a/core/src/mothra.rs
+++ b/core/src/mothra.rs
@@ -128,7 +128,7 @@ fn spawn_mothra(
         // perform termination tasks when the network is being shutdown
         if let Ok(Async::Ready(_)) | Err(_) = exit_rx.poll() {
                     // network thread is terminating TODO
-                    // let enrs: Vec<Enr> = service.libp2p.swarm.enr_entries().cloned().collect();
+                    // let enrs: Vec<Enr<CombinedKey>> = service.libp2p.swarm.enr_entries().cloned().collect();
                     // debug!(
                     //     log,
                     //     "Persisting DHT to store";


### PR DESCRIPTION
- reduce gossipsub heartbeat interval
- removed all eth2 dependencies
- removed custom Enr type definition (caused confusion when using mothra and discv5 directly in imp)
- libp2p version now just selected  in patch

resolves #57 